### PR TITLE
release v1.11.0 changelog and docs

### DIFF
--- a/docs/channels/overview.mdx
+++ b/docs/channels/overview.mdx
@@ -12,7 +12,7 @@ For example, you may have a "leaderboard" channel that publishes messages that e
 
 There is no limit to the number of channels your application can have and channels do not need to be declared ahead of time. When any message is published to a channel, any currently subscribed listeners receive a copy of that message.
 
-Channel names can be any string between 1 to 256 characters and must not contain asterisks (`*`), hashes (`#`), commas (`,`), spaces, or newline characters.
+Channel names can be any string between 1 to 256 characters and must not contain asterisks (`*`), hashes (`#`), commas (`,`), spaces, or newline characters. In JWT claims, channel keys support wildcards (`*`) and regex patterns (`#regex:`) for flexible permission matching.
 
 ## Events
 

--- a/docs/connections/claims.mdx
+++ b/docs/connections/claims.mdx
@@ -38,7 +38,7 @@ Per the JWT spec, `aud` can also be an array of audiences, where the installatio
 
 ## `channels` {#channels}
 
-`Object` (optional) - The `channels` claim specifies the channel permissions granted and channel directives assigned to this connection. Each object key is the name of a channel and can include asterisks (\*) anywhere in the string to denote wildcards. Each object value is another object with the settings for that channel or channel wildcard.
+`Object` (optional) - The `channels` claim specifies the channel permissions granted and channel directives assigned to this connection. Each object key is the name of a channel and can include asterisks (\*) anywhere in the string to denote wildcards. Keys can also use the `#regex:` prefix to specify a regular expression pattern for matching channel names. Each object value is another object with the settings for that channel or channel pattern.
 
 The following grants subscribe access to any channel with the prefix `account.123.` and the channel named `user.456`.
 
@@ -71,6 +71,29 @@ For wildcards that overlap, any explicit `false` is used as the value and cannot
   }
 }
 ```
+
+#### Regex patterns {#channels--regex}
+
+In addition to wildcards, channel keys can use the `#regex:` prefix to specify a [Go regular expression](https://pkg.go.dev/regexp/syntax) pattern. This enables fine-grained permission control for dynamically-named channels where wildcards are not precise enough.
+
+The following grants subscribe access to any channel where the name starts with `org.` followed by one or more digits.
+
+```json
+{
+  // highlight-next-line
+  "channels": {
+    "#regex:^org\\.[0-9]+$": {
+      "subscribe": true
+    }
+  }
+}
+```
+
+Regex patterns are compiled and validated when the token is parsed. Invalid patterns cause the token to be rejected. Regex patterns follow the same precedence rules as wildcards — an explicit `false` from any matching pattern always wins.
+
+:::info
+Regex patterns cannot have an [`alias`](#channels.alias) or [`autoSubscribe`](#channels.autoSubscribe) defined on them, just like wildcard patterns.
+:::
 
 Each object inside the channels object accepts [`alias`](#channels.alias), [`autoSubscribe`](#channels.autoSubscribe), [`historyStart`](#channels.historyStart), [`messages`](#channels.messages), [`omitFromSubCount`](#channels.omitFromSubCount), and [`subscribe`](#channels.subscribe) attributes.
 
@@ -186,9 +209,36 @@ If you wanted to allow access to the entire message history of a channel without
 
 ### `messages` {#channels.messages}
 
-`Object` (optional) - Manages the permissions and directives for client-initiated messages that are published directly to the WebSocket on the channel(s) for the specified events. Each object key is the name of an event and can include asterisks (\*) anywhere in the string to denote wildcards. Each object value is another object with the settings for that event or event wildcard.
+`Object` (optional) - Manages the permissions and directives for client-initiated messages that are published directly to the WebSocket on the channel(s) for the specified events. Each object key is the name of an event and can include asterisks (\*) anywhere in the string to denote wildcards. Keys can also use the `#regex:` prefix to specify a regular expression pattern for matching event names. Each object value is another object with the settings for that event or event pattern.
 
 Each object inside the messages object accepts [`broadcast`](#channels.messages.broadcast), [`echo`](#channels.messages.echo), [`emitPubSubEvent`](#channels.messages.emitPubSubEvent), [`publish`](#channels.messages.publish), [`scheduleBefore`](#channels.messages.scheduleBefore), and [`store`](#channels.messages.store) attributes.
+
+#### Regex patterns {#channels.messages--regex}
+
+In addition to wildcards, event keys can use the `#regex:` prefix to specify a [Go regular expression](https://pkg.go.dev/regexp/syntax) pattern. This enables fine-grained permission control for event names where wildcards are not precise enough.
+
+The following allows the connection to publish `move` events and any event matching the pattern `action.{digits}` on the "game.123" channel.
+
+```json
+{
+  "channels": {
+    "game.123": {
+      "subscribe": true,
+      "messages": {
+        "move": {
+          "publish": true
+        },
+        // highlight-next-line
+        "#regex:^action\\.[0-9]+$": {
+          "publish": true
+        }
+      }
+    }
+  }
+}
+```
+
+Regex patterns in event keys are compiled and validated when the token is parsed. Invalid patterns cause the token to be rejected. Regex patterns follow the same precedence rules as wildcards — an explicit `false` from any matching pattern always wins.
 
 #### `broadcast` {#channels.messages.broadcast}
 

--- a/docs/installation/changelog.mdx
+++ b/docs/installation/changelog.mdx
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.11.0 - March 19, 2026 {#v1.11.0}
+
+- Add [regex pattern support](../connections/claims.mdx#channels--regex) for channel name patterns in JWT claims. Channel keys can now use the `#regex:` prefix for [Go regular expression](https://pkg.go.dev/regexp/syntax) matching, enabling fine-grained permission control for dynamically-named channels where wildcards are not precise enough.
+- Add [regex pattern support](../connections/claims.mdx#channels.messages--regex) for event name patterns in JWT message claims. Event keys inside `messages` can use the same `#regex:` prefix for matching event names. Regex patterns are validated at token parse time.
+- Allow `#` in event names except as a prefix, reserving the `#regex:` namespace for pattern directives while permitting `#` elsewhere in event names.
+- Return friendly error messages for type mismatches in message input. When clients send incorrect types like `{"event": ["badarray"]}` instead of a string, the error now clearly indicates what went wrong instead of exposing internal Go type information.
+- Fix a panic in the logging library when writing failed error logs.
+- Update all aws-sdk-go-v2 SDK modules to their latest versions (as of [2026-03-13](https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2026-03-13)).
+
 ## v1.10.1 - March 10, 2026 {#v1.10.1}
 
 - Doubles the channel name limit from 128 to 256 characters to accommodate real-world use cases approaching the limit.

--- a/docs/server-api/publish-messages.mdx
+++ b/docs/server-api/publish-messages.mdx
@@ -263,7 +263,7 @@ Deduplication is handled [internally by SQS](https://docs.aws.amazon.com/AWSSimp
 
 ### `event` {#message-format.event}
 
-`String` (required) - The name of the event to publish to the channel. This can be any string up to 128 characters, but must not begin with `hotsock.` and must not contain any asterisk (`*`) characters.
+`String` (required) - The name of the event to publish to the channel. This can be any string up to 128 characters, but must not begin with `hotsock.` or `#`, and must not contain any asterisk (`*`) characters.
 
 ### `scheduleExpression` {#message-format.scheduleExpression}
 


### PR DESCRIPTION
## Summary

- Add v1.11.0 changelog entry with links to new documentation sections
- Document `#regex:` pattern support for channel name matching and message event name matching in JWT claims, each with dedicated linkable sections and inline examples
- Note the reserved `#` prefix restriction for event names in publish-messages and channels overview docs