### PR TITLE
Homepage content refresh and subtle visual lift

### DIFF
--- a/src/components/landing/Capabilities.js
+++ b/src/components/landing/Capabilities.js
@@ -1,0 +1,146 @@
+import React from "react"
+import Link from "@docusaurus/Link"
+import Wrapper from "../global/Wrapper"
+
+const CAPABILITIES = [
+  {
+    title: "Private & presence channels",
+    description:
+      "JWT-gated subscriptions with built-in presence tracking and per-member metadata.",
+    href: "/docs/channels/presence/",
+    icon: "◉",
+  },
+  {
+    title: "Channel storage",
+    description:
+      "Persistent per-key state delivered to subscribers on join, with independent TTLs.",
+    href: "/docs/channels/storage/",
+    icon: "▣",
+    badge: "New",
+  },
+  {
+    title: "Live metadata updates",
+    description:
+      "Change a connection's user metadata on the fly. No reconnecting, no resubscribing.",
+    href: "/docs/connections/claims/#umdUpdate",
+    icon: "↻",
+    badge: "New",
+  },
+  {
+    title: "Auto-subscribe on connect",
+    description:
+      "Skip the subscribe round-trip. Clients join their channels the moment they connect.",
+    href: "/docs/connections/claims/#channels.autoSubscribe",
+    icon: "⚡",
+  },
+  {
+    title: "Channel aliases",
+    description:
+      "Keep internal IDs off the client. Issue a friendly alias in the token and subscribe with it.",
+    href: "/docs/connections/claims/#channels.alias",
+    icon: "⇄",
+  },
+  {
+    title: "Scheduled messages",
+    description:
+      "Publish a message now, deliver it later. Backed by EventBridge Scheduler.",
+    href: "/docs/server-api/publish-messages/#message-format.scheduleExpression",
+    icon: "⏱",
+  },
+  {
+    title: "Message storage & history",
+    description:
+      "Retain messages per-event and query them by channel and event name, sorted by time.",
+    href: "/docs/connections/client-http-api/",
+    icon: "▦",
+  },
+  {
+    title: "Broadcast to unsubscribed",
+    description:
+      "Publish from a client to any channel it has permission for. No subscription required.",
+    href: "/docs/connections/claims/#channels.messages.broadcast",
+    icon: "⇡",
+  },
+  {
+    title: "Pub/sub to SNS & EventBridge",
+    description:
+      "Fan connection, message, and storage events out to the rest of your AWS workload.",
+    href: "/docs/server-api/events/",
+    icon: "☷",
+  },
+  {
+    title: "Regex & wildcard claims",
+    description:
+      "Grant permission to dynamic channel and event names with wildcard or Go regex patterns.",
+    href: "/docs/connections/claims/#channels--regex",
+    icon: "⟨⟩",
+  },
+  {
+    title: "Custom domains",
+    description:
+      "Keep WebSocket connections on your own domain for consistent branding and trust.",
+    href: "/docs/installation/custom-domains/",
+    icon: "⌂",
+  },
+  {
+    title: "Built-in web console",
+    description:
+      "Debug JWTs, connections, subscriptions, storage, and publish messages from the browser.",
+    href: "/docs/server-api/web-console/",
+    icon: "▤",
+  },
+]
+
+function Capabilities() {
+  return (
+    <div className="w-full py-16 lg:py-24 border-solid border-t border-b border-x-0 border-gray-100 dark:border-slate-800">
+      <Wrapper>
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <p className="text-primary text-sm font-semibold uppercase tracking-wider mb-3">
+            Everything you'd build yourself, already built
+          </p>
+          <h2 className="text-3xl lg:text-5xl font-bold tracking-tight mb-4">
+            Your complete WebSocket platform
+          </h2>
+          <p className="text-lg lg:text-xl text-gray-700 dark:text-gray-300 leading-relaxed">
+            Hotsock includes the primitives real-time apps need: presence,
+            storage, scheduling, message history, and event fan-out. You can
+            focus on your product instead of reinventing the messaging layer.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {CAPABILITIES.map((cap) => (
+            <Link
+              key={cap.title}
+              to={cap.href}
+              className="group relative block rounded-xl border border-solid border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900/40 p-5 no-underline hover:no-underline hover:border-primary/60 hover:shadow-md transition-all"
+            >
+              <div className="flex items-start gap-4">
+                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 text-primary flex items-center justify-center text-xl font-bold">
+                  {cap.icon}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap mb-1">
+                    <h3 className="text-base font-semibold m-0 text-gray-900 dark:text-white group-hover:text-primary transition-colors">
+                      {cap.title}
+                    </h3>
+                    {cap.badge && (
+                      <span className="text-[10px] font-semibold uppercase tracking-wider rounded-full bg-primary/10 text-primary px-2 py-0.5">
+                        {cap.badge}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 m-0 leading-relaxed">
+                    {cap.description}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </Wrapper>
+    </div>
+  )
+}
+
+export default Capabilities

--- a/src/components/landing/FeaturesNew.js
+++ b/src/components/landing/FeaturesNew.js
@@ -7,81 +7,87 @@ import Link from "@docusaurus/Link"
 
 const FEATURES = [
   {
-    title: "Security on your terms",
+    title: "Privacy is the default",
     imageUrl: "/img/private.png",
     description: (
       <>
-        No one wants to learn their data was used for AI training or part of a
-        multi-tenant breach. All services are run privately in <em>your</em> AWS
-        account. Your data{" "}
-        <strong className="text-primary">always remains yours</strong>,{" "}
+        No one wants to learn their data was used for AI training or caught in a
+        multi-tenant breach. Every byte flows through services that run
+        privately in <em>your</em> AWS account. Your data{" "}
+        <strong className="text-primary">always remains yours</strong>, and is{" "}
         <strong className="text-primary">only accessible by you</strong>.
       </>
     ),
     target: "/docs/installation/security/",
   },
-  // {
-  //   title: "Unlimited Everything",
-  //   imageUrl: "/img/unlimited.png",
-  //   description: (
-  //     <>
-  //       Design and incorporate{" "}
-  //       <strong className="text-primary">real-time messaging</strong> the way
-  //       that makes the most sense for your applications with{" "}
-  //       <strong className="text-primary">unlimited</strong> connections,
-  //       channels, and messages.
-  //     </>
-  //   ),
-  //   target: "",
-  // },
   {
-    title: "Presence Channels",
+    title: "Presence, out of the box",
     imageUrl: "/img/chat.png",
     description: (
       <>
-        Track who's online or what devices are currently subscribed to the same
-        channel. Great for chat rooms and document collaboration where you need
-        awareness of other active participants.
+        Know <strong className="text-primary">who</strong> is online,{" "}
+        <strong className="text-primary">where</strong>, and on{" "}
+        <strong className="text-primary">what device</strong>. You never have to
+        build a presence service yourself. Per-member metadata can be updated
+        live, and every member gets an event when someone joins, leaves, or
+        changes state.
       </>
     ),
     target: "/docs/channels/presence/",
   },
   {
-    title: "Custom Domains",
+    title: "Persistent channel storage",
+    imageUrl: "/img/unlimited.png",
+    description: (
+      <>
+        Channels can now carry{" "}
+        <strong className="text-primary">persistent key-value state</strong>{" "}
+        that every subscriber reads on join. Keep configuration, room settings,
+        feature flags, shared cursors, or game state on the channel and stop
+        round-tripping to your backend. Each key has its own TTL and permission
+        scope.
+      </>
+    ),
+    target: "/docs/channels/storage/",
+  },
+  {
+    title: "Your domain, your branding",
     imageUrl: "/img/domains.png",
     description: (
       <>
-        Maintain consistent branding and customer trust by keeping WebSocket
-        connections on your own domain name.
+        Host WebSocket connections on your own domain. Your customers never see
+        a third-party host, your TLS certificate is managed by ACM, and
+        switching providers later is a DNS change away.
       </>
     ),
     target: "/docs/installation/custom-domains/",
   },
   {
-    title: "Web Console",
+    title: "Web console for everything",
     imageUrl: "/img/console.png",
     description: (
       <>
-        Easily debug and test JWT validation, token claims, connections, channel
-        subscriptions, and messages.
+        A built-in console for JWTs, connections, subscriptions, channel
+        storage, and publishing. It ships with JSON syntax highlighting, mobile
+        support, and message filtering. Debugging a real-time bug should not
+        require building your own test harness.
       </>
     ),
     target: "/docs/server-api/web-console",
   },
   {
-    title: "Serverless",
+    title: "Serverless to the core",
     imageUrl: "/img/serverless.png",
     description: (
       <>
-        Powered by on-demand services such as{" "}
-        <strong className="text-primary">API Gateway</strong>,{" "}
+        Built on <strong className="text-primary">API Gateway</strong>,{" "}
         <strong className="text-primary">DynamoDB</strong>,{" "}
         <strong className="text-primary">Lambda</strong>,{" "}
         <strong className="text-primary">EventBridge</strong>,{" "}
         <strong className="text-primary">SNS</strong>, and{" "}
-        <strong className="text-primary">SQS</strong>. It scales to zero when
-        you're not using it or can handle millions of connections and billions
-        of messages for high-volume production workloads.
+        <strong className="text-primary">SQS</strong>. Scales to zero while
+        idle, fans out to millions of connections and billions of messages under
+        production load, and costs only what AWS charges you.
       </>
     ),
     target: "/docs/installation/initial-setup/#aws-services",
@@ -92,10 +98,13 @@ function NewFeatures() {
   return (
     <Wrapper>
       <div className="space-y-8 my-12">
-        <div className="text-center">
-          <h1 className="text-3xl m-0 text-center lg:text-4xl">
-            Just some of the features...
-          </h1>
+        <div className="text-center max-w-3xl mx-auto py-8">
+          <p className="text-primary text-sm font-semibold uppercase tracking-wider mb-3">
+            A closer look
+          </p>
+          <h2 className="text-3xl lg:text-5xl font-bold tracking-tight m-0">
+            The details that matter in production
+          </h2>
         </div>
         {FEATURES.map((feature, idx) => (
           <FeatureAnimation key={idx} idx={idx} feature={feature} />

--- a/src/components/landing/Hero.js
+++ b/src/components/landing/Hero.js
@@ -8,21 +8,38 @@ import Certificate from "../../icons/certificate"
 
 function Hero() {
   return (
-    <div className="hero-bg w-full py-10  lg:py-16 flex text-center flex-col items-center justify-center">
+    <div className="hero-bg relative w-full py-12 lg:py-20 flex text-center flex-col items-center justify-center overflow-hidden">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 flex items-start justify-center"
+      >
+        <div className="w-[60rem] h-[60rem] -translate-y-1/3 rounded-full bg-primary/10 dark:bg-primary/10 blur-3xl" />
+      </div>
       <Wrapper>
-        <div className="lg:w-9/12  mx-auto">
-          <h1 className="lg:text-5xl text-3xl !leading-[44px] lg:!leading-[65px] ">
-            Add stunning real-time features to your applications without limits
-            or privacy trade-offs.
+        <div className="relative lg:w-10/12 mx-auto">
+          <Link
+            to="/blog/channel-storage-and-umd-updates"
+            className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/5 px-3 py-1 text-xs font-medium text-primary no-underline hover:bg-primary/10 hover:no-underline mb-6"
+          >
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+            Now available · v1.12 channel storage &amp; live user metadata
+            <Arrow className="fill-current w-3 h-3" />
+          </Link>
+          <h1 className="lg:text-6xl text-4xl font-bold !leading-[1.1] lg:!leading-[1.1] tracking-tight mb-6">
+            Real-time WebSockets,{" "}
+            <span className="bg-gradient-to-r from-primary to-pink-400 bg-clip-text text-transparent">
+              fully private
+            </span>
+            , infinitely scalable, installed in minutes.
           </h1>
-          <p className="text-lg lg:text-xl !leading-[36px] lg:!leading-[40px]">
-            Hotsock is a fully-private WebSocket messaging service that runs{" "}
-            <strong>in your AWS account</strong>. Add chat, notifications, live
-            updates, and presence to your applications with simple APIs—no
-            servers to manage, no scaling complexity, and your data stays yours.
-            Installs in minutes.
+          <p className="text-lg lg:text-xl !leading-[1.7] lg:!leading-[1.7] max-w-3xl mx-auto text-gray-700 dark:text-gray-300">
+            Hotsock is a production-ready WebSocket messaging service that runs
+            entirely <strong>in your AWS account</strong>. Ship chat, presence,
+            live dashboards, notifications, and collaboration without managing
+            servers, paying per-connection, or handing your data to a third
+            party.
           </p>
-          <div className="flex flex-col lg:flex-row  max-lg:space-y-4 lg:space-x-4 w-full items-center justify-center">
+          <div className="flex flex-col lg:flex-row mt-8 max-lg:space-y-4 lg:space-x-4 w-full items-center justify-center">
             <Link
               className={`flex max-lg:w-full flex-row items-center group ${buttonVariants(
                 {
@@ -31,13 +48,9 @@ function Hero() {
               )}`}
               href="/docs/installation/initial-setup/"
             >
-              <span
-                className="mr-3 group-hover:mr-5
-              ease-in-out transition-all duration-200
-              "
-              >
-                Launch your installation
-              </span>{" "}
+              <span className="mr-3 group-hover:mr-5 ease-in-out transition-all duration-200">
+                Launch your free installation
+              </span>
               <Arrow className="fill-current " />
             </Link>
             <Link
@@ -49,26 +62,25 @@ function Hero() {
               )}`}
               href="/examples/real-time-chat/"
             >
-              <span
-                className="mr-3
-              "
-              >
-                See a demo
-              </span>
+              <span className="mr-3">See a live demo</span>
             </Link>
           </div>
-          <div className="flex flex-col lg:flex-row items-center justify-center max-lg:space-y-2 lg:space-x-6 mt-6 text-gray-600 dark:text-gray-400 text-sm">
+          <div className="flex flex-col lg:flex-row flex-wrap items-center justify-center max-lg:space-y-2 lg:gap-x-6 mt-8 text-gray-600 dark:text-gray-400 text-sm">
             <p className="max-lg:m-0 flex flex-row items-center space-x-2">
               <Chart />
-              <span>Automatically scales to your workload</span>
+              <span>Scales to millions of connections</span>
             </p>
             <p className="flex flex-row items-center space-x-2">
               <Certificate />
-              <span>Supported in 22 AWS regions</span>
+              <span>Available in 22 AWS regions</span>
             </p>
             <p className="flex flex-row items-center space-x-2">
-              <span>✓</span>
-              <span>Free forever tier</span>
+              <span className="text-primary">✓</span>
+              <span>1M messages/month, free forever</span>
+            </p>
+            <p className="flex flex-row items-center space-x-2">
+              <span className="text-primary">✓</span>
+              <span>No per-connection fees</span>
             </p>
           </div>
         </div>

--- a/src/components/landing/Pricing.js
+++ b/src/components/landing/Pricing.js
@@ -204,7 +204,7 @@ function PricingTable() {
               ease-in-out transition-all duration-200
               "
           >
-            Launch your installation
+            Launch your free installation
           </span>{" "}
           <Arrow className="fill-current " />
         </Link>

--- a/src/components/landing/ReleaseCadence.js
+++ b/src/components/landing/ReleaseCadence.js
@@ -1,0 +1,118 @@
+import React from "react"
+import Link from "@docusaurus/Link"
+import Wrapper from "../global/Wrapper"
+import Arrow from "../../icons/arrow"
+
+const RELEASES = [
+  {
+    version: "v1.12",
+    date: "April 2026",
+    title: "Channel storage & live user metadata",
+    summary:
+      "Persistent per-key state on channels, and live umd updates without reconnecting.",
+    href: "/blog/channel-storage-and-umd-updates",
+  },
+  {
+    version: "v1.11",
+    date: "March 2026",
+    title: "Regex patterns in claims",
+    summary:
+      "Go regex support for channel and event name claims, with friendlier errors.",
+    href: "/docs/installation/changelog/#v1.11.0",
+  },
+  {
+    version: "v1.10",
+    date: "March 2026",
+    title: "Channel aliases & large-channel fan-out",
+    summary:
+      "Friendly client-side channel names and automatic fan-out past 250 subscribers.",
+    href: "/blog/channel-aliases-and-large-channel-fan-out",
+  },
+  {
+    version: "v1.9",
+    date: "February 2026",
+    title: "Fresh web console",
+    summary:
+      "JSON syntax highlighting, mobile-friendly layout, message filtering, 1MB pub/sub.",
+    href: "/docs/installation/changelog/#v1.9.0",
+  },
+  {
+    version: "v1.8",
+    date: "October 2025",
+    title: "Message history & tracing",
+    summary:
+      "Query stored messages by channel and event, with connection/source metadata attached.",
+    href: "/docs/installation/changelog/#v1.8.0",
+  },
+  {
+    version: "v1.7",
+    date: "September 2025",
+    title: "Auto-subscribe & broadcast",
+    summary:
+      "Channels subscribed the moment you connect, and publishing to channels you're not on.",
+    href: "/blog/auto-subscribe-and-broadcast-messaging",
+  },
+]
+
+function ReleaseCadence() {
+  return (
+    <div className="w-full py-16 lg:py-24 bg-[#FDF6FA] dark:bg-slate-800/40">
+      <Wrapper>
+        <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-6 mb-10">
+          <div className="max-w-2xl">
+            <p className="text-primary text-sm font-semibold uppercase tracking-wider mb-3">
+              Shipping every month
+            </p>
+            <h2 className="text-3xl lg:text-5xl font-bold tracking-tight mb-4">
+              Active, steady, backwards-compatible
+            </h2>
+            <p className="text-lg text-gray-700 dark:text-gray-300 leading-relaxed m-0">
+              Every release is a single CloudFormation update away.
+              Installations with auto-update turned on get them for free.
+            </p>
+          </div>
+          <Link
+            to="/docs/installation/changelog/"
+            className="inline-flex items-center gap-2 text-primary font-medium no-underline hover:no-underline hover:gap-3 transition-all"
+          >
+            View full changelog
+            <Arrow className="fill-current w-4 h-4" />
+          </Link>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {RELEASES.map((r, idx) => (
+            <Link
+              key={r.version}
+              to={r.href}
+              className="group relative flex flex-col rounded-xl bg-white dark:bg-slate-900/60 border border-solid border-gray-200 dark:border-slate-700 p-5 no-underline hover:no-underline hover:border-primary/60 hover:shadow-md transition-all"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span className="inline-flex items-center gap-2">
+                  <span className="text-sm font-mono font-bold text-primary">
+                    {r.version}
+                  </span>
+                  {idx === 0 && (
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-white bg-primary rounded-full px-2 py-0.5">
+                      Latest
+                    </span>
+                  )}
+                </span>
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {r.date}
+                </span>
+              </div>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-white m-0 mb-2 group-hover:text-primary transition-colors">
+                {r.title}
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed m-0">
+                {r.summary}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </Wrapper>
+    </div>
+  )
+}
+
+export default ReleaseCadence

--- a/src/components/landing/UseCases.js
+++ b/src/components/landing/UseCases.js
@@ -1,0 +1,104 @@
+import React from "react"
+import Link from "@docusaurus/Link"
+import Wrapper from "../global/Wrapper"
+import Arrow from "../../icons/arrow"
+
+const USE_CASES = [
+  {
+    label: "Chat",
+    title: "Real-time chat & messaging",
+    description:
+      "Threaded conversations, typing indicators, read receipts, and online status. Presence channels do the heavy lifting.",
+    href: "/examples/real-time-chat/",
+    features: ["Presence channels", "Typing indicators", "Per-user metadata"],
+  },
+  {
+    label: "Dashboards",
+    title: "Live dashboards & telemetry",
+    description:
+      "Push metrics, logs, and KPIs from your backend to every connected browser with a single publish call.",
+    href: "/examples/live-dashboard/",
+    features: [
+      "Server-published updates",
+      "Billions of messages",
+      "Auto fan-out",
+    ],
+  },
+  {
+    label: "Collaboration",
+    title: "Collaborative editing",
+    description:
+      "Shared to-do lists, documents, boards, and cursors. Message history and channel storage keep every client in sync.",
+    href: "/examples/collaborative-todo/",
+    features: ["Message storage", "Channel storage", "History on reconnect"],
+  },
+  {
+    label: "Notifications",
+    title: "Notification feeds",
+    description:
+      "Deliver notifications to a user the instant they land. Users receive them even on pages they haven't explicitly subscribed to.",
+    href: "/examples/notification-feed/",
+    features: ["Auto-subscribe", "Channel aliases", "Broadcast messaging"],
+  },
+]
+
+function UseCases() {
+  return (
+    <div className="w-full py-16 lg:py-24">
+      <Wrapper>
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <p className="text-primary text-sm font-semibold uppercase tracking-wider mb-3">
+            Built for the apps you actually build
+          </p>
+          <h2 className="text-3xl lg:text-5xl font-bold tracking-tight mb-4">
+            From first message to production scale
+          </h2>
+          <p className="text-lg lg:text-xl text-gray-700 dark:text-gray-300 leading-relaxed">
+            Each of the patterns below ships as a live, interactive demo. Open
+            the source, copy the JWT claim, and drop it into your app.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {USE_CASES.map((uc) => (
+            <Link
+              key={uc.title}
+              to={uc.href}
+              className="group flex flex-col rounded-2xl border border-solid border-gray-200 dark:border-slate-700 bg-gradient-to-br from-white to-pink-50/30 dark:from-slate-900/60 dark:to-slate-900/20 p-7 no-underline hover:no-underline hover:border-primary/60 hover:shadow-lg transition-all"
+            >
+              <span className="self-start text-[11px] font-semibold uppercase tracking-widest text-primary bg-primary/10 px-2.5 py-1 rounded-full mb-4">
+                {uc.label}
+              </span>
+              <h3 className="text-xl lg:text-2xl font-semibold text-gray-900 dark:text-white mb-3 group-hover:text-primary transition-colors">
+                {uc.title}
+              </h3>
+              <p className="text-base text-gray-600 dark:text-gray-400 leading-relaxed mb-5 flex-grow">
+                {uc.description}
+              </p>
+              <div className="mb-5">
+                <p className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 m-0 mb-2">
+                  Features used
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {uc.features.map((f) => (
+                    <span
+                      key={f}
+                      className="text-xs font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-slate-800 rounded-md px-2 py-1"
+                    >
+                      {f}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-primary font-medium text-sm">
+                <span>Try the live demo</span>
+                <Arrow className="fill-current w-4 h-4 group-hover:translate-x-1 transition-transform" />
+              </div>
+            </Link>
+          ))}
+        </div>
+      </Wrapper>
+    </div>
+  )
+}
+
+export default UseCases

--- a/src/icons/arrow.js
+++ b/src/icons/arrow.js
@@ -5,6 +5,7 @@ function Arrow({ className }) {
       xmlns="http://www.w3.org/2000/svg"
       width="18"
       height="14"
+      viewBox="0 0 18 14"
       id="arrow"
     >
       <g

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,18 +3,16 @@ import Layout from "@theme/Layout"
 import HomepageBanner from "@site/src/components/HomepageBanner"
 import Hero from "../components/landing/Hero"
 import Sections from "../components/landing/Sections"
-// import Testimonials from "../components/landing/Testimonials"
+import Capabilities from "../components/landing/Capabilities"
 import FeaturesNew from "../components/landing/FeaturesNew"
-// import TrustStats from "../components/landing/TrustStats"
+import UseCases from "../components/landing/UseCases"
+import ReleaseCadence from "../components/landing/ReleaseCadence"
 import PricingTable from "../components/landing/Pricing"
-// import { OrganizationSchema, ProductSchema } from "../components/StructuredData"
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext()
   return (
     <>
-      {/* <OrganizationSchema /> */}
-      {/* <ProductSchema /> */}
       <HomepageBanner />
       <Layout
         title="Private, self-hosted, and fully managed real-time messaging service"
@@ -22,9 +20,10 @@ export default function Home() {
       >
         <Hero />
         <Sections />
+        <Capabilities />
         <FeaturesNew />
-        {/* <TrustStats /> */}
-        {/* <Testimonials /> */}
+        <UseCases />
+        <ReleaseCadence />
         <PricingTable />
       </Layout>
     </>


### PR DESCRIPTION
## Summary
- Expands the homepage with three new sections — a Capabilities grid, Use cases tied to the live examples, and a release-cadence strip — so recent features (channel storage, live umd updates, channel aliases, auto-subscribe, scheduled messages, broadcast, regex claims) are actually marketed from the homepage.
- Refreshes the Hero with a gradient accent, a "Now available" pill linking to the v1.12 post, and an expanded stat strip; rewrites FeaturesNew copy and adds a Persistent channel storage deep-dive; updates the primary CTA to "Launch your free installation".
- Fixes the shared Arrow SVG so it no longer clips when sized down (added ``viewBox``), which affects every Arrow usage on the homepage.

## Test plan
- [ ] ``npm run start`` and visually verify the homepage in light and dark mode
- [ ] Confirm ``npm run build`` succeeds
- [ ] Click through each new section link to confirm docs/blog targets still resolve