### PR TITLE
Update docs for Hotsock v1.13.2

### DIFF
--- a/docs/installation/changelog.mdx
+++ b/docs/installation/changelog.mdx
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.13.2 - June 11, 2026 {/* #v1.13.2 */}
+
+- Performance improvements including lower-overhead hot-path JSON handling, improved AWS HTTP connection reuse, and shorter AWS SDK retry/backoff timing.
+- Add sampled lightweight tracing spans to application logs. Spans are structured JSON log records with `type: "app.span"`, `traceId`, `spanId`, timing, status, and correlation fields that can be queried in CloudWatch Logs Insights. Configure with the new "Tracing spans in logs sample rate (%)" (`TracesInLogsSampleRateParameter` via CLI) setting; the default sample rate is `1` (1%), and setting it to `0` disables tracing.
+- Improve the CloudWatch overview dashboard with clearer metric labels, min/average/max Lambda duration views, and message processing function metrics. DynamoDB table metrics now link to the DynamoDB console instead of consuming additional dashboard widgets.
+- Reduce the default consolidated log retention for new installations from 365 days to 90 days. Existing installations keep their configured value unless changed.
+- Improve automatic updates so the updater can retry after filtering CloudFormation parameters that no longer exist in the latest template.
+- Fix a `umdUpdate` bug where updating user metadata for a disconnected connection or missing subscription could create incomplete DynamoDB records.
+- Build with Go 1.26.4.
+- Update all aws-sdk-go-v2 SDK modules to their latest versions (as of [2026-06-10](https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2026-06-10)).
+
 ## v1.13.1 - May 20, 2026 {/* #v1.13.1 */}
 
 - Stop publishing zero-duration metrics for EventBridge and SNS publishing in the stream processor functions when no call to the service is made, as it skews averages and other metric math. Zero-count metrics are still published.

--- a/docs/installation/initial-setup.mdx
+++ b/docs/installation/initial-setup.mdx
@@ -219,6 +219,10 @@ Upon successful creation of your Hotsock stack, the root CloudFormation stack ha
 ![Outputs tab items](../../static/img/screenshots/initial-setup-outputs-tab.png)
 :::
 
+### AutoUpdateInstallation {/* #AutoUpdateInstallation */}
+
+This indicates whether automatic installation updates are currently `enabled` or `disabled`. Automatic updates run once per day when enabled. See [Update Your Installation](./updates.mdx) for details about automatic and manual updates.
+
 ### HttpApiSecretKey1ConsoleUrl {/* #HttpApiSecretKey1ConsoleUrl */}
 
 This is the URL where you can find the primary secret key value for API calls to the `PublishHttpApiUrl`. To access the secret value, go to this URL and click the "Show" link by the "Value" label, which will reveal a 40-character secret key that must be used as a Bearer token in the Authorization header of all HTTP API requests.
@@ -267,9 +271,7 @@ If this URL's value is blank, the installation is already adopted by a Hotsock a
 
 The URL of a CloudWatch Dashboard that combines important metrics about your installation in a single place.
 
-:::info[Example Output Value]
-![LicensingUrl example output](../../static/img/screenshots/initial-setup-outputs-LicensingUrl.png)
-:::
+This value is blank if the monitoring overview dashboard is disabled.
 
 ### PublishFunctionArn {/* #PublishFunctionArn */}
 

--- a/docs/server-api/logging.mdx
+++ b/docs/server-api/logging.mdx
@@ -10,7 +10,7 @@ Hotsock logs are written to [CloudWatch Logs](https://docs.aws.amazon.com/Amazon
 
 By default, all application logs from Lambda functions are written to the same CloudWatch Logs log group. This aggregates all log entries to one place for searching or following in real-time.
 
-Consolidated logging also allows configuring a log retention policy for these logs so you're not paying for their storage forever. Log retention defaults to 365 days (1 year), but you can [change this in your installation's settings](#change-log-settings).
+Consolidated logging also allows configuring a log retention policy for these logs so you're not paying for their storage forever. Log retention defaults to 90 days, but you can [change this in your installation's settings](#change-log-settings).
 
 ## System log settings {/* #system-log-settings */}
 
@@ -36,8 +36,18 @@ To minimize log volume while retaining important messages, `WARN` is a reasonabl
 :::warning
 The `DEBUG` log level can incur significant costs on large-scale installations. Consider using this log level temporarily to capture logs for a given situation, then restore the setting to one of the less verbose log levels.
 
-Additionally, the `DEBUG` level logs all messages as they are received and published, including the payloads. These entries may contain sensitive information. Be sure to review your CloudWatch Logs permissions and retention settings if you're enabling `DEBUG` loging for a production workload.
+Additionally, the `DEBUG` level logs all messages as they are received and published, including the payloads. These entries may contain sensitive information. Be sure to review your CloudWatch Logs permissions and retention settings if you're enabling `DEBUG` logging for a production workload.
 :::
+
+## Tracing spans in logs {/* #tracing-spans-in-logs */}
+
+Hotsock can emit lightweight tracing spans as structured JSON application log records. These records have `type: "app.span"` and include fields such as `traceId`, `spanId`, `parentSpanId`, `spanName`, `status`, `startEpochMs`, and `durationMs`.
+
+Tracing is sampled per trace and is configured by the CloudFormation "Tracing spans in logs sample rate (%)" (`TracesInLogsSampleRateParameter` via CLI) setting. The value is a percentage from `0` to `100`; `0` disables tracing entirely. The default is `1`, which samples roughly 1% of traces.
+
+Sampled traces are correlated across Hotsock's asynchronous Lambda, SQS, SNS, and EventBridge hops where possible. Use the shared `traceId` to query related `app.span` records in CloudWatch Logs Insights.
+
+Tracing spans are application log records, so they require the application log level to be `INFO` or `DEBUG`. They add log volume for sampled traces, so raise the sample rate temporarily when investigating an issue and lower it again when finished.
 
 ## Change log settings {/* #change-log-settings */}
 
@@ -51,7 +61,7 @@ You'll be prompted with the "Prepare template" screen and can keep "Use current 
 
 ![Step 1 - Use current template option](../../static/img/screenshots/logging-main-stack-update-step-1.png)
 
-On the "Specify stack details" screen, you can configure **"Consolidate logs to single log group"**, **"Log level (application logs)"**, **"Log level (system logs)"**, and **"Log retention (number of days)"**.
+On the "Specify stack details" screen, you can configure **"Consolidate logs to single log group"**, **"Log level (application logs)"**, **"Log level (system logs)"**, **"Log retention (number of days)"**, and **"Tracing spans in logs sample rate (%)"**.
 
 ![Step 2 - Specify stack details](../../static/img/screenshots/logging-main-stack-update-logging-settings.png)
 


### PR DESCRIPTION
## Summary
- Add v1.13.2 release notes covering performance work, tracing spans, dashboard updates, log retention, updater resilience, the umdUpdate fix, and dependency/runtime updates.
- Document the tracing span log setting and 90-day log retention default.
- Bring initial setup stack output docs up to date, including AutoUpdateInstallation and MonitoringOverviewDashboardUrl.

## Validation
- npm run build